### PR TITLE
Connect metadata

### DIFF
--- a/service/getPath.go
+++ b/service/getPath.go
@@ -1,5 +1,14 @@
 package service
 
+import (
+	"api/util"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
 type MetadataRequestStruct struct {
 	APIs ApiSlice
 }
@@ -44,6 +53,17 @@ type ParametersStruct struct {
 	Body         map[string]interface{}
 }
 
+type DslInfoStruct struct {
+	Id        int64          `gorm:"column:id" bson:"_id"`
+	Name      string         `gorm:"column:name" bson:"name"`
+	Path      string         `gorm:"column:path" bson:"path"`
+	Content   string         `gorm:"column:content" bson:"content"`
+	Method    string         `gorm:"column:method" bson:"method"`
+	CreatedAt time.Time      `gorm:"created_at;<-:create" bson:"created_at"`
+	UpdatedAt time.Time      `gorm:"updated_at;<-:update" bson:"updated_at"`
+	Deleted   gorm.DeletedAt `gorm:"deleted" bson:"deleted"`
+}
+
 func (api *ApiSlice) Len() int {
 	return len(*api)
 }
@@ -56,112 +76,156 @@ func (api *ApiSlice) Swap(i, j int) {
 	(*api)[i], (*api)[j] = (*api)[j], (*api)[i]
 }
 
+// 一个朴素的想法就是直接调用metadata的dsl/list()接口
 func GetPathFromMetadata(path string, method string) MetadataRequestStruct {
-	api := ApiStruct{
-		Services: ServicesStruct{
-			Host: "127.0.0.1",
-			Port: "8081",
-		},
-		Path:     "/ping",
-		Protocol: "http",
-		Method:   "GET",
-		Parameter: []ParametersStruct{{
-			Key:          "id",
-			DefaultValue: "string",
-			Require:      true,
-			Type:         "query",
-			Body:         nil,
-		}, {
-			Key:          "id",
-			DefaultValue: "string",
-			Require:      true,
-			Type:         "body",
-			Body: map[string]interface{}{
-				"test": "12345",
-			},
-		}},
-		BatchIndex: 0,
-		Name:       "ping",
-	}
-	api2 := ApiStruct{
-		Services: ServicesStruct{
-			Host: "127.0.0.1",
-			Port: "8081",
-		},
-		Path:     "/ping1",
-		Protocol: "http",
-		Method:   "GET",
-		Parameter: []ParametersStruct{{
-			Key:          "id",
-			Type:         "query",
-			DefaultValue: "string",
-			Require:      true,
-			Body:         nil,
-		}},
-		Headers: []HeaderStruct{{
-			Key:          "jwt",
-			DefaultValue: "token",
-		}, {
-			Key:          "Content-Type",
-			DefaultValue: "application/pdf",
-		}},
-		BatchIndex: 1,
-		ParentApi: []ParentApiStruct{{
-			ParentName:   "ping",
-			Key:          "rewq",
-			DefaultValue: 0,
-			ToType:       "query",
-			ToKey:        "ewqe",
-		}, {
-			ParentName:   "ping",
-			Key:          "message",
-			DefaultValue: 0,
-			ToType:       "body",
-			ToKey:        "test1",
-		}, {
-			ParentName:   "ping",
-			Key:          "message1",
-			DefaultValue: 0,
-			ToType:       "body",
-			ToKey:        "test2",
-		}, {
-			ParentName:   "ping",
-			Key:          "message2.test.try",
-			DefaultValue: 0,
-			ToType:       "body",
-			ToKey:        "test3.test.try",
-		}},
-		Name: "ping1",
+	//根据传入的聚合请求的path和method构造对dsl/list的查询请求
+	newBody := make(map[string]interface{})
+	query := make(map[string]string)
+	header := make(map[string]string)
+	var contentType string
+	failed := false
+
+	Method := "Get"
+	//这个URL不知道怎么写
+	url := "http://100.100.30.74:8080/v1/dsl/list"
+	query["Path"] = path
+	query["Method"] = method
+
+	bodyByte, err := json.Marshal(newBody)
+	if err != nil {
+		failed = true
 	}
 
-	api3 := ApiStruct{
-		Services: ServicesStruct{
-			Host: "127.0.0.1",
-			Port: "8081",
-		},
-		Path:     "/postPing",
-		Protocol: "http",
-		Method:   "POST",
-		Parameter: []ParametersStruct{{
-			Key:          "postIds",
-			DefaultValue: "12324 ",
-			Require:      true,
-			Type:         "query",
-			Body:         nil,
-		}, {
-			Key:          "",
-			DefaultValue: "",
-			Require:      true,
-			Type:         "json",
-			Body: map[string]interface{}{
-				"rerqwe": "123",
-			},
-		}},
-		BatchIndex: 0,
-		Name:       "postPing",
+	subResp, code := util.Do(Method, url, header, query, bodyByte, contentType)
+	subMap := make(map[string]interface{})
+	err = json.Unmarshal([]byte(subResp), &subMap)
+	if code != 200 {
+		failed = true
+	}
+	if err != nil {
+		failed = true
+	}
+
+	//这里有个问题就是，content=>ApiStruct在这里写还是在metadata里写
+	//在这里写需要把DslInfoStruct在这里重新定义
+	//在metadata里写需要添加接口或者修改接口
+	dslContentStr := strings.Split(subMap["res"].(DslInfoStruct).Content, "\"APIs\":")[1]
+	var dslInfoStructs []ApiStruct
+	err = json.Unmarshal([]byte(dslContentStr), &dslInfoStructs)
+	if err != nil {
+		failed = true
 	}
 
 	request := make(map[string]MetadataRequestStruct)
-	request["testOne"] = MetadataRequestStruct{APIs: []ApiStruct{api, api2, api3}}
-	return request["testOne"]
+	request["testOne"] = MetadataRequestStruct{APIs: dslInfoStructs}
+
+	if failed == false {
+		return request["testOne"]
+	} else {
+		//如果前面发生错误，这里就返回一个模拟的APi数组
+		api := ApiStruct{
+			Services: ServicesStruct{
+				Host: "127.0.0.1",
+				Port: "8081",
+			},
+			Path:     "/ping",
+			Protocol: "http",
+			Method:   "GET",
+			Parameter: []ParametersStruct{{
+				Key:          "id",
+				DefaultValue: "string",
+				Require:      true,
+				Type:         "query",
+				Body:         nil,
+			}, {
+				Key:          "id",
+				DefaultValue: "string",
+				Require:      true,
+				Type:         "body",
+				Body: map[string]interface{}{
+					"test": "12345",
+				},
+			}},
+			BatchIndex: 0,
+			Name:       "ping",
+		}
+		api2 := ApiStruct{
+			Services: ServicesStruct{
+				Host: "127.0.0.1",
+				Port: "8081",
+			},
+			Path:     "/ping1",
+			Protocol: "http",
+			Method:   "GET",
+			Parameter: []ParametersStruct{{
+				Key:          "id",
+				Type:         "query",
+				DefaultValue: "string",
+				Require:      true,
+				Body:         nil,
+			}},
+			Headers: []HeaderStruct{{
+				Key:          "jwt",
+				DefaultValue: "token",
+			}, {
+				Key:          "Content-Type",
+				DefaultValue: "application/pdf",
+			}},
+			BatchIndex: 1,
+			ParentApi: []ParentApiStruct{{
+				ParentName:   "ping",
+				Key:          "rewq",
+				DefaultValue: 0,
+				ToType:       "query",
+				ToKey:        "ewqe",
+			}, {
+				ParentName:   "ping",
+				Key:          "message",
+				DefaultValue: 0,
+				ToType:       "body",
+				ToKey:        "test1",
+			}, {
+				ParentName:   "ping",
+				Key:          "message1",
+				DefaultValue: 0,
+				ToType:       "body",
+				ToKey:        "test2",
+			}, {
+				ParentName:   "ping",
+				Key:          "message2.test.try",
+				DefaultValue: 0,
+				ToType:       "body",
+				ToKey:        "test3.test.try",
+			}},
+			Name: "ping1",
+		}
+		api3 := ApiStruct{
+			Services: ServicesStruct{
+				Host: "127.0.0.1",
+				Port: "8081",
+			},
+			Path:     "/postPing",
+			Protocol: "http",
+			Method:   "POST",
+			Parameter: []ParametersStruct{{
+				Key:          "postIds",
+				DefaultValue: "12324 ",
+				Require:      true,
+				Type:         "query",
+				Body:         nil,
+			}, {
+				Key:          "",
+				DefaultValue: "",
+				Require:      true,
+				Type:         "json",
+				Body: map[string]interface{}{
+					"rerqwe": "123",
+				},
+			}},
+			BatchIndex: 0,
+			Name:       "postPing",
+		}
+		request["ErrorOne"] = MetadataRequestStruct{APIs: []ApiStruct{api, api2, api3}}
+		return request["ErrorOne"]
+	}
 }

--- a/service/getPath.go
+++ b/service/getPath.go
@@ -86,8 +86,10 @@ func GetPathFromMetadata(path string, method string) MetadataRequestStruct {
 	failed := false
 
 	Method := "Get"
-	//这个URL不知道怎么写
-	url := "http://100.100.30.74:8080/v1/dsl/list"
+	//注意端口映射
+	url := "http://100.100.30.74:32346/v1/dsl/list"
+	//有一个大问题就是这里的token。这玩意要登录的.为了防止麻烦。直接写死一个。
+	header["ApiToken"] = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxNjA3MjkwNDY1ODQzOTQxMzc2LCJleHAiOjE2NzQ1NDQ5NjUsImlzcyI6Imp3dCJ9.n4aOKtwM-hvSDHYlvLqWIZN1udWNhbNT90c860ZFy6w"
 	query["Path"] = path
 	query["Method"] = method
 


### PR DESCRIPTION
先交个草稿看一下。代码思路就是在这个`GetPathFromMetadata`方法里调用`metadata`的`dsl/list()`接口，然后在这里解析`content`到`ApiStruct`。
讨论以下几个点：
- `metadata`的接口（主要是url里的ip地址）怎么写？
- 我`content`的解析方法写的很糙，就直接按`”APIs“`字符串分割搞得
- 解析`content`应该在`API`模块里写（当前是在`API`），还是在`metadata`里添加接口或者修改接口，
- 关于你之前说得打通两种方法里提到的同步，我其实没太理解，同步什么？从我的角度看，`API`模块和`metadata`模块之间唯一的联系就是需要从`metadata`里得到”聚合的请求“对应的`[]APIStruct`。所以怎么用nacos做同步就没啥想法。